### PR TITLE
Replace deprecated flatMap API with compactMap

### DIFF
--- a/Xcode/Closures/Source/UIImagePickerController.swift
+++ b/Xcode/Closures/Source/UIImagePickerController.swift
@@ -111,7 +111,7 @@ extension UIImagePickerController {
             cameraOverlayView = cameraOverlay
             self.showsCameraControls = showsCameraControls
         }
-        mediaTypes = UIImagePickerController.MediaFilter.allTypes.flatMap {
+        mediaTypes = UIImagePickerController.MediaFilter.allTypes.compactMap {
             allow.contains($0) ? $0.mediaType : nil
         }
         didFinishPickingMedia { [unowned self] in


### PR DESCRIPTION
This change provides Swift 4.1 support by replacing the old API. `compactMap` should now be used to filter out `nil` from arrays.