### PR TITLE
Xcode16 Support

### DIFF
--- a/Xcode/Closures/Source/Core.swift
+++ b/Xcode/Closures/Source/Core.swift
@@ -20,11 +20,11 @@
 
 import Foundation
 
-protocol DelegateProtocol: class {
+protocol DelegateProtocol: AnyObject {
 }
 
 @available(iOS 9.0, *)
-public protocol DelegatorProtocol: class {
+public protocol DelegatorProtocol: AnyObject {
     /**
      Clears any delegates/datasources that were assigned by the `Closures`
      framework for this object. This cleans up memory as well as sets the

--- a/Xcode/Closures/Source/UIControl.swift
+++ b/Xcode/Closures/Source/UIControl.swift
@@ -334,7 +334,7 @@ extension UITextField {
      * returns: itself so you can daisy chain the other event handler calls
      */
     @discardableResult
-    public func onReturn(handler: @escaping () -> Void) -> Self {
+    public func onReturnKeyPress(handler: @escaping () -> Void) -> Self {
         on(.editingDidEndOnExit) { _,_ in
             handler()
         }


### PR DESCRIPTION
Change the "onReturn" function name to the "onReturnKeyPress" to avoid duplicate function names in Xcode 16