### PR TITLE
Fix for Xcode 16 as onReturn function name is conflict with Xcode by default function name

### DIFF
--- a/Supporting/cocoapods/Closures.podspec.json
+++ b/Supporting/cocoapods/Closures.podspec.json
@@ -2,7 +2,7 @@
   "name": "Closures",
   "version": "0.7",
   "summary": "Swifty closures for UIKit and Foundation",
-  "homepage": "https://github.com/vhesener/Closures",
+  "homepage": "https://github.com/KrishnaM0618/Closures",
   "screenshots": [
     "https://raw.githubusercontent.com/vhesener/Closures/assets/assets/playground_general.gif",
     "https://raw.githubusercontent.com/vhesener/Closures/assets/assets/reference_large.png"
@@ -13,7 +13,7 @@
     "ios": "9.0"
   },
   "source": {
-    "git": "https://github.com/vhesener/Closures.git",
+    "git": "https://github.com/KrishnaM0618/Closures.git",
     "tag": "v0.7"
   },
   "source_files": "Xcode/Closures/Source",

--- a/Xcode/Closures.xcodeproj/project.pbxproj
+++ b/Xcode/Closures.xcodeproj/project.pbxproj
@@ -434,7 +434,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Closures/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vhesener.Closures;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -457,7 +457,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Closures/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.vhesener.Closures;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Xcode/Closures/Source/Core.swift
+++ b/Xcode/Closures/Source/Core.swift
@@ -20,11 +20,11 @@
 
 import Foundation
 
-protocol DelegateProtocol: class {
+protocol DelegateProtocol: AnyObject {
 }
 
 @available(iOS 9.0, *)
-public protocol DelegatorProtocol: class {
+public protocol DelegatorProtocol: AnyObject {
     /**
      Clears any delegates/datasources that were assigned by the `Closures`
      framework for this object. This cleans up memory as well as sets the

--- a/Xcode/Closures/Source/UIControl.swift
+++ b/Xcode/Closures/Source/UIControl.swift
@@ -334,7 +334,7 @@ extension UITextField {
      * returns: itself so you can daisy chain the other event handler calls
      */
     @discardableResult
-    public func onReturn(handler: @escaping () -> Void) -> Self {
+    public func onReturnKeyPress(handler: @escaping () -> Void) -> Self {
         on(.editingDidEndOnExit) { _,_ in
             handler()
         }


### PR DESCRIPTION
Fix for Xcode 16 as onReturn function name is conflict with Xcode by default function name
Now changed the "onReturn" function name to the "onReturnKeyPress"